### PR TITLE
switching to faster readRaster call in GdalUtility

### DIFF
--- a/Gdal2Tiles/src/com/rgi/g2t/GdalTileJob.java
+++ b/Gdal2Tiles/src/com/rgi/g2t/GdalTileJob.java
@@ -24,7 +24,6 @@ package com.rgi.g2t;
 
 import java.awt.Color;
 import java.io.File;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
@@ -275,11 +274,11 @@ public class GdalTileJob implements Runnable {
                 final GdalRasterParameters params = GdalUtility.getGdalRasterParameters(dataset.GetGeoTransform(), tileBBox, this.tileDimensions, dataset);
 
                 // Read image data directly from the raster
-                final ByteBuffer imageData = GdalUtility.readRasterDirect(params, dataset);
+                final byte[] imageData = GdalUtility.readRaster(params, dataset);
 
                 // TODO: logic goes here in the case that the querysize == tile size (gdalconstConstants.GRA_NearestNeighbour) (write directly)
                 // Time to start writing the tile
-                final Dataset querySizeImageCanvas = GdalUtility.writeRasterDirect(params, imageData, dataset.GetRasterCount());
+                final Dataset querySizeImageCanvas = GdalUtility.writeRaster(params, imageData, dataset.GetRasterCount());
 
                 // Scale each band of tileDataInMemory down to the tile size (down from the query size)
                 final Dataset tileDataInMemory = GdalUtility.scaleQueryToTileSize(querySizeImageCanvas, this.tileDimensions);


### PR DESCRIPTION
Switched to the apparently faster ReadRaster call using a byte array directly.