### PR TITLE
Add ExtensionImplementation.java to the list of ignored test files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,9 @@
                                 <!-- Ignore the verifier app -->
                                 <excludes>com/rgi/verifiertool/**/*.class</excludes>
 
-                                <!-- Ignore extension exception and interface -->
+                                <!-- Ignore extension exception, abstract class, and interface -->
                                 <excludes>com/rgi/geopackage/extensions/implementation/BadImplementationException*.class</excludes>
+                                <excludes>com/rgi/geopackage/extensions/implementation/ExtensionImplementation*.class</excludes>
                                 <excludes>com/rgi/geopackage/extensions/implementation/ImplementsExtension*.class</excludes>
 
                                 <!-- Ignore schema verifiers -->


### PR DESCRIPTION
This file is abstract with no concrete implementations in the GeoPackage project.  The concrete implementation exists in NetworkExtension and is tested there.