### PR TITLE
ignore tile verifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
                                 <excludes>com/rgi/geopackage/extensions/ExtensionsVerifier*.class</excludes>
                                 <excludes>com/rgi/geopackage/metadata/MetadataVerifier*.class</excludes>
                                 <excludes>com/rgi/geopackage/schema/SchemaVerifier*.class</excludes>
+                                <excludes>com/rgi/geopackage/tiles/TilesVerifier*.class</excludes>
                             </excludes>
                         </instrumentation>
                     </configuration>


### PR DESCRIPTION
All the other verifiers are ignored BUT the tile verifier.  It should be ignored (it is a test itself)