### PR TITLE
Updating installer for GDAL 2.0 on windows

### DIFF
--- a/WiX/SWAGD.wxs
+++ b/WiX/SWAGD.wxs
@@ -20,8 +20,8 @@
       
       <!-- List components that go in or reference in the installdir, eg C:\Program Files\swagd, which is the default defined above.
             these include path shortcuts-->
-      <Property Id="INSTALLDIR"  />
-      <Property Id="withDeps"/>
+      <Property Id="INSTALLDIR" Secure="yes" />
+      <Property Id="WITHDEPS" Secure="yes" />
       
       <!-- swagd components -->
       <DirectoryRef Id="INSTALLDIR">
@@ -42,12 +42,12 @@
         
         <!-- set path variables-->
         <Component Id="gdalDataPath" Guid="EF67942F-D3D9-492B-824D-CCE63B10B805" Win64="yes">
-          <Condition><![CDATA[withDeps <> "0"]]></Condition>
+          <Condition><![CDATA[WITHDEPS <> "0"]]></Condition>
           <CreateFolder />
           <Environment Id="gdaldatapath" Name="GDAL_DATA" Value="[INSTALLDIR]GDAL\gdal-data" Permanent="no" Part="all" Action="set" System="yes" />
         </Component>
         <Component Id="gdalPath" Guid="E69183C0-F599-45EB-925F-F9D09432577F" Win64="yes">
-          <Condition><![CDATA[withDeps <> "0"]]></Condition>
+          <Condition><![CDATA[WITHDEPS <> "0"]]></Condition>
           <CreateFolder />
           <Environment Id="gdalpath" Name="Path" Value="[INSTALLDIR]GDAL" Permanent="no" Part="last" Action="set" System="yes" />
         </Component>

--- a/WiX/Swagd-deps.wxs
+++ b/WiX/Swagd-deps.wxs
@@ -50,7 +50,7 @@
     <!-- Bundle Installer Chain. Components in the packageGroup will be installed in the order they are listed.-->
     <Fragment>
       <PackageGroup Id="InstallGDAL">
-        <MsiPackage SourceFile=".\Resources\gdal-111-1800-x64-core.msi"
+        <MsiPackage SourceFile=".\Resources\gdal-201-1800-x64-core.msi"
                     Visible="yes"
                     Description="Gdal Core Libraries"
                     InstallCondition="NOT gdalCoreInstalled"
@@ -59,7 +59,7 @@
                     >
           <MsiProperty Name="INSTALLDIR" Value="[InstallFolder]GDAL\" />
         </MsiPackage>
-        <MsiPackage SourceFile=".\Resources\gdal-111-1800-x64-mrsid.msi"
+        <MsiPackage SourceFile=".\Resources\gdal-201-1800-x64-mrsid.msi"
                     Visible="yes"
                     Description="GDAL Mr.SID library extensions"
                     InstallCondition="NOT gdalMrSidInstalled"
@@ -72,7 +72,7 @@
         Its also set to permanant, so uninstalling swagd will not remove the java install. -->
         <ExePackage Id="InstallJava"
                     InstallCondition="NOT (JAVA_CURRENT_VERSION= &quot;1.8&quot;)"
-                    SourceFile=".\Resources\jre-8u45-windows-x64.exe"
+                    SourceFile=".\Resources\jre-8u77-windows-x64.exe"
                     Compressed="yes"
                     Permanent="yes"
                     />


### PR DESCRIPTION
* Fixing installer warnings
* Updating installers to GDAL 2.0.1 on Windows release executables (see pre-release)